### PR TITLE
Enable overriding nomad props: args and canary

### DIFF
--- a/deploy/deployer.go
+++ b/deploy/deployer.go
@@ -357,7 +357,9 @@ func (d *Deployer) validate() error {
 	if s.Node != "" {
 		d.job.Constrain(api.NewConstraint("${meta.node}", "=", s.Node))
 	}
-
+	if s.Canary != nil {
+		d.job.Update.Canary = s.Canary
+	}
 	for _, tg := range d.job.TaskGroups {
 		if !(*tg.Name == d.service || *tg.Name == "services") {
 			continue
@@ -374,7 +376,9 @@ func (d *Deployer) validate() error {
 			ta.Config["image"] = d.image
 			s.Image = d.image
 			log.S("image", s.Image).Debug("setting")
-
+			if len(s.Args) > 0 {
+				ta.Config["args"] = s.Args
+			}
 			if s.CPU != 0 {
 				ta.Resources.CPU = &s.CPU
 				log.I("cpu", s.CPU).Debug("setting")

--- a/deploy/deployment_config.go
+++ b/deploy/deployment_config.go
@@ -117,12 +117,14 @@ func (c *DeploymentConfig) load() error {
 // ServiceConfig represent structure for config.yml
 type ServiceConfig struct {
 	Image       string
+	Args        []string          `yaml:"args,omitempty"`
 	Count       int               `yaml:"count,omitempty"`
 	HostGroup   string            `yaml:"hostgroup,omitempty"`
 	Node        string            `yaml:"node,omitempty"`
 	CPU         int               `yaml:"cpu,omitempty"`
 	Memory      int               `yaml:"mem,omitempty"`
 	Environment map[string]string `yaml:"env,omitempty"`
+	Canary      *int              `yaml:"canary,omitempty"`
 }
 
 // Save changes to config.yml


### PR DESCRIPTION
In staging environment we should be able to pick some specific features
of a service by providing custom args.

Also, we don't have need for canary deployments in staging. Since there
is usually only one host on staging deployment, canary along with
distinct_host property causes deployment to fail. This gives an option
to disable canary for staging environments.