### PR TITLE
Add option to replace nomad job arguments for starting service

### DIFF
--- a/deploy/deployer.go
+++ b/deploy/deployer.go
@@ -371,10 +371,13 @@ func (d *Deployer) validate() error {
 			if !(ta.Name == d.service || ta.Name == "service") {
 				continue
 			}
+
+			// set image
 			ta.Config["image"] = d.image
 			s.Image = d.image
 			log.S("image", s.Image).Debug("setting")
 
+			// set resources
 			if s.CPU != 0 {
 				ta.Resources.CPU = &s.CPU
 				log.I("cpu", s.CPU).Debug("setting")
@@ -383,6 +386,14 @@ func (d *Deployer) validate() error {
 				ta.Resources.MemoryMB = &s.Memory
 				log.I("memory", s.Memory).Debug("setting")
 			}
+
+			// replace arguments
+			if len(s.Arguments) > 0 {
+				log.I("args_len", len(s.Arguments)).Debug("setting")
+				ta.Config["args"] = s.Arguments
+			}
+
+			// set environment variables
 			if d.config.FederatedDcs != "" {
 				ta.Env[FederatedDcsEnv] = d.config.FederatedDcs
 			}

--- a/deploy/deployment_config.go
+++ b/deploy/deployment_config.go
@@ -123,6 +123,7 @@ type ServiceConfig struct {
 	CPU         int               `yaml:"cpu,omitempty"`
 	Memory      int               `yaml:"mem,omitempty"`
 	Environment map[string]string `yaml:"env,omitempty"`
+	Arguments   []string          `yaml:"arg,omitempty"`
 }
 
 // Save changes to config.yml

--- a/deploy/deployment_config_test.go
+++ b/deploy/deployment_config_test.go
@@ -1,0 +1,74 @@
+package deploy
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLoadConfig(t *testing.T) {
+	// load invalid configuration
+	cfg, err := NewDeploymentConfig("./fixture", "test2")
+	assert.Error(t, err)
+	assert.NotNil(t, cfg)
+	assert.Len(t, cfg.Datacenters, 0) // number of datacenters
+
+	// load valid configuration
+	cfg, err = NewDeploymentConfig("./fixture", "test")
+	assert.NoError(t, err)
+	assert.NotNil(t, cfg)
+	assert.Equal(t, "datacenter1 datacenter2", cfg.FederatedDcs) // fedrated dscs
+	assert.Len(t, cfg.Datacenters, 3)                            // number of datacenters
+
+	// find one service
+	svc := cfg.Find("service_test1")
+	assert.NotNil(t, svc)
+
+	// find one service in datacenter
+	svc = cfg.FindForDc("service_test1", "datacenter1")
+	assert.NotNil(t, svc)
+
+	// find non existing service in datacenter
+	svc = cfg.FindForDc("service_test1", "datacenter2")
+	assert.Nil(t, svc)
+
+	// all avaliable service names
+	allsvc := cfg.serviceNames()
+	assert.Len(t, allsvc, 3)
+
+	// all datacenters for service
+	alldc := cfg.FindDatacenters("service_test2")
+	assert.Len(t, alldc, 2)
+}
+
+func TestLoadServiceParams(t *testing.T) {
+	// load valid configuration
+	cfg, err := NewDeploymentConfig("./fixture", "test")
+	assert.NoError(t, err)
+	assert.NotNil(t, cfg)
+
+	// find one service in datacenter
+	svc := cfg.FindForDc("service_test1", "datacenter1")
+	assert.NotNil(t, svc)
+
+	// check values
+	assert.Equal(t, "service_test1_image", svc.Image)
+	assert.Equal(t, 1, svc.Count)
+	assert.Equal(t, "app", svc.HostGroup)
+	assert.Equal(t, "app1", svc.Node)
+	assert.Equal(t, 64, svc.CPU)
+	assert.Equal(t, 128, svc.Memory)
+
+	// check environmet
+	assert.Len(t, svc.Environment, 5)
+	for k, v := range svc.Environment {
+		assert.Equal(t, k+"_set", v)
+	}
+
+	// check arguments
+	assert.Len(t, svc.Arguments, 4)
+	assert.Equal(t, "-argument", svc.Arguments[0])
+	assert.Equal(t, "argument_set", svc.Arguments[1])
+	assert.Equal(t, "-argument_var1", svc.Arguments[2])
+	assert.Equal(t, "argument_var1_set", svc.Arguments[3])
+}

--- a/deploy/fixture/deployments/test/config.yml
+++ b/deploy/fixture/deployments/test/config.yml
@@ -1,0 +1,29 @@
+federated_dcs: datacenter1 datacenter2
+datacenters:
+    datacenter1:
+        services:
+            service_test1:
+                image: service_test1_image
+                count: 1
+                hostgroup: app
+                node: app1
+                cpu: 64
+                mem: 128
+                env:
+                    env_var1: "env_var1_set"
+                    env_var2: "env_var2_set"
+                    env-var3: "env-var3_set"
+                    envCamelCase: "envCamelCase_set"
+                    ENV_UPPERCASE: "ENV_UPPERCASE_set"
+                arg: ["-argument", "argument_set", "-argument_var1", "argument_var1_set"]
+            service_test2:
+                image: service_test2_image
+                count: 2
+                hostgroup: svc
+    datacenter2: {}
+    datacenter3:
+        services:
+            service_test2:
+                image: service_test2_image
+                count: 2
+                hostgroup: svc


### PR DESCRIPTION
Related to task:
https://3.basecamp.com/3077084/buckets/10103289/todos/2116868448

This change enables replacing arguments of starting service in nomad job definition using config.yml
In effect this allows to deploy of
- same service
- with same nomad job definition
- to different environments
- started with completely with different arguments

Arguments from config.yml always override arguments in nomad job definition.
Key under service definition for arguments is **"arg"**.

Here is example of service with defined arguments:
```
      dbi:
        image: registry.dev.minus5.hr/dbi:20191219121031.771124b.14187d08.dcf7bb6
        cpu: 128
        mem: 128
        arg: ["-push_not","false", "-db_to_nsq","true", "-db", "user=app_web_backend;password=app_web_backend;server=mssql.s.minus5.hr;database=SuperSportTest_bruof;max_pool_size=500;lock_timeout=15000"]
```

Arguments in config yml can also be defined like this (instead one line array)
```
      dbi:
        image: registry.dev.minus5.hr/dbi:20200110135952.771124b.14187d08.00037ca
        cpu: 128
        mem: 128
        arg:
        - -push_not
        - "false"
        - -db_to_nsq
        - "true"
        - -db
        - user=app_web_backend;password=app_web_backend;server=mssql.s.minus5.hr;database=SuperSportTest_bruof;max_pool_size=500;lock_timeout=15000
```

Arguments can also be environment variables that nomad would replace when executing job see doc:
https://www.nomadproject.io/docs/drivers/docker.html#args
