### PR TITLE
Add option to set volumes through config.yml

### DIFF
--- a/deploy/deployer.go
+++ b/deploy/deployer.go
@@ -407,6 +407,11 @@ func (d *Deployer) validate() error {
 				}
 			}
 
+			// replace volumes
+			if len(s.Volumes) > 0 {
+				log.I("vol_len", len(s.Volumes)).Debug("setting")
+				ta.Config["volumes"] = s.Volumes
+			}
 		}
 	}
 

--- a/deploy/deployment_config.go
+++ b/deploy/deployment_config.go
@@ -124,6 +124,7 @@ type ServiceConfig struct {
 	Memory      int               `yaml:"mem,omitempty"`
 	Environment map[string]string `yaml:"env,omitempty"`
 	Arguments   []string          `yaml:"arg,omitempty"`
+	Volumes     []string          `yaml:"vol,omitempty"`
 }
 
 // Save changes to config.yml

--- a/deploy/deployment_config_test.go
+++ b/deploy/deployment_config_test.go
@@ -71,4 +71,9 @@ func TestLoadServiceParams(t *testing.T) {
 	assert.Equal(t, "argument_set", svc.Arguments[1])
 	assert.Equal(t, "-argument_var1", svc.Arguments[2])
 	assert.Equal(t, "argument_var1_set", svc.Arguments[3])
+
+	// check volumes
+	assert.Len(t, svc.Volumes, 2)
+	assert.Equal(t, "name-of-the-volume1:/path/in/container1", svc.Volumes[0])
+	assert.Equal(t, "name-of-the-volume2:/path/in/container2", svc.Volumes[1])
 }

--- a/deploy/fixture/deployments/test/config.yml
+++ b/deploy/fixture/deployments/test/config.yml
@@ -16,6 +16,7 @@ datacenters:
                     envCamelCase: "envCamelCase_set"
                     ENV_UPPERCASE: "ENV_UPPERCASE_set"
                 arg: ["-argument", "argument_set", "-argument_var1", "argument_var1_set"]
+                vol: ["name-of-the-volume1:/path/in/container1","name-of-the-volume2:/path/in/container2"]
             service_test2:
                 image: service_test2_image
                 count: 2


### PR DESCRIPTION
- when defined in config.yml volumes overirde definition in nomad job
- volumes are set with "vol" key that is string array

Than you can volumes like this:
```
            service_test1:
                image: service_test1_image
                count: 1
                hostgroup: app
                node: app1
                cpu: 64
                mem: 128
                env:
                    env_var1: "env_var1_set"
                    env_var2: "env_var2_set"
                    env-var3: "env-var3_set"
                    envCamelCase: "envCamelCase_set"
                    ENV_UPPERCASE: "ENV_UPPERCASE_set"
                arg: ["-argument", "argument_set", "-argument_var1", "argument_var1_set"]
                vol: ["name-of-the-volume1:/path/in/container1","name-of-the-volume2:/path/in/container2"]
```